### PR TITLE
Fix form network

### DIFF
--- a/zigpy_zboss/uart.py
+++ b/zigpy_zboss/uart.py
@@ -275,7 +275,7 @@ async def connect(config: conf.ConfigType, api) -> ZbossNcpProtocol:
     baudrate = config[conf.CONF_DEVICE_BAUDRATE]
     flow_control = config[conf.CONF_DEVICE_FLOW_CONTROL]
 
-    LOGGER.info("Connecting to %s at %s baud", port, baudrate)
+    LOGGER.debug("Connecting to %s at %s baud", port, baudrate)
 
     _, protocol = await zigpy.serial.create_serial_connection(
         loop=loop,
@@ -292,5 +292,7 @@ async def connect(config: conf.ConfigType, api) -> ZbossNcpProtocol:
     except asyncio.TimeoutError:
         protocol.close()
         raise RuntimeError("Could not communicate with NCP!")
+
+    LOGGER.debug("Connected to %s at %s baud", port, baudrate)
 
     return protocol


### PR DESCRIPTION
This is fixing the issue we get when zigpy is trying to form a network when the NCP dongle has been factory reset.
Now, the ieee of the coordinator will always use its default value (defined by ZBOSS) and only write another ieee if the zigpy backup is telling to do so.