### PR TITLE
Rename permit_with_key to permit_with_link_key

### DIFF
--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -463,7 +463,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
         )
 
-    def permit_with_link_key(self, node, code, time_s=60):
+    def permit_with_link_key(self, node, link_key, time_s=60):
         """Permit with link key."""
         raise NotImplementedError
 

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -463,8 +463,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
         )
 
-    def permit_with_key(self, node, code, time_s=60):
-        """Permit with key."""
+    def permit_with_link_key(self, node, code, time_s=60):
+        """Permit with link key."""
         raise NotImplementedError
 
     @property


### PR DESCRIPTION
I guess the Zigpy project changed this method, so we need to keep up.

Before this change, I got an error like this:

  File "/home/nate/.local/lib/python3.10/site-packages/zigpy_cli/radio.py", line 66, in radio
    app = app_cls(config)
TypeError: Can't instantiate abstract class ControllerApplication with abstract method permit_with_link_key

I assume the method was renamed upstream, so let's just rename it too.