### PR TITLE
Introduce compatibility with recent zigpy changes and improve UART reset stability

### DIFF
--- a/zigpy_zboss/api.py
+++ b/zigpy_zboss/api.py
@@ -101,7 +101,8 @@ class ZBOSS:
         Propagates up to the `ControllerApplication` that owns this ZBOSS
         instance.
         """
-        LOGGER.debug("We were disconnected from %s: %s", self._port_path, exc)
+        if self._app is not None:
+            self._app.connection_lost(exc)
 
     def close(self) -> None:
         """Clean up resources, namely the listener queues.

--- a/zigpy_zboss/api.py
+++ b/zigpy_zboss/api.py
@@ -182,6 +182,8 @@ class ZBOSS:
             raise ValueError(
                 f"Cannot send a command that isn't a request: {request!r}")
 
+        LOGGER.debug("Sending request: %s", request)
+
         frame = request.to_frame()
         # If the frame is too long, it needs fragmentation.
         fragments = frame.handle_tx_fragmentation()

--- a/zigpy_zboss/api.py
+++ b/zigpy_zboss/api.py
@@ -297,7 +297,7 @@ class ZBOSS:
         """
         listener = IndicationListener(responses, callback=callback)
 
-        LOGGER.debug(f"Creating callback {listener}")
+        LISTENER_LOGGER.debug(f"Creating callback {listener}")
 
         for header in listener.matching_headers():
             self._listeners[header].append(listener)

--- a/zigpy_zboss/types/commands.py
+++ b/zigpy_zboss/types/commands.py
@@ -717,5 +717,5 @@ class Relationship(t.enum8):
 STATUS_SCHEMA = (
     t.Param("TSN", t.uint8_t, "Transmit Sequence Number"),
     t.Param("StatusCat", StatusCategory, "Status category code"),
-    t.Param("StatusCode", t.uint8_t, "Status code inside category"),
+    t.Param("StatusCode", StatusCodeGeneric, "Status code inside category"),
 )

--- a/zigpy_zboss/types/named.py
+++ b/zigpy_zboss/types/named.py
@@ -36,42 +36,11 @@ class BindAddrMode(basic.enum8):
     IEEE = 0x03
 
 
-class ChannelEntry:
+class ChannelEntry(Struct):
     """Class representing a channel entry."""
 
-    def __new__(cls, page=None, channel_mask=None):
-        """Create a channel entry instance."""
-        instance = super().__new__(cls)
-
-        instance.page = basic.uint8_t(page)
-        instance.channel_mask = channel_mask
-
-        return instance
-
-    @classmethod
-    def deserialize(cls, data: bytes) -> "ChannelEntry":
-        """Deserialize the object."""
-        page, data = basic.uint8_t.deserialize(data)
-        channel_mask, data = Channels.deserialize(data)
-
-        return cls(page=page, channel_mask=channel_mask), data
-
-    def serialize(self) -> bytes:
-        """Serialize the object."""
-        return self.page.serialize() + self.channel_mask.serialize()
-
-    def __eq__(self, other):
-        """Return True if channel_masks and pages are equal."""
-        if not isinstance(other, type(self)):
-            return NotImplemented
-
-        return self.page == other.page and \
-            self.channel_mask == other.channel_mask
-
-    def __repr__(self) -> str:
-        """Return a representation of a channel entry."""
-        return f"{type(self).__name__}(page={self.page!r}," \
-            f" channels={self.channel_mask!r})"
+    page: basic.uint8_t
+    channel_mask: Channels
 
 
 @dataclasses.dataclass(frozen=True)

--- a/zigpy_zboss/uart.py
+++ b/zigpy_zboss/uart.py
@@ -81,6 +81,8 @@ class ZbossNcpProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc: typing.Optional[Exception]) -> None:
         """Lost connection."""
+        LOGGER.debug("Connection has been lost: %r", exc)
+
         if self._api is not None:
             self._api.connection_lost(exc)
 
@@ -240,8 +242,6 @@ async def connect(config: conf.ConfigType, api) -> ZbossNcpProtocol:
     port = config[conf.CONF_DEVICE_PATH]
     baudrate = config[conf.CONF_DEVICE_BAUDRATE]
     flow_control = config[conf.CONF_DEVICE_FLOW_CONTROL]
-
-    LOGGER.debug("Connecting to %s at %s baud", port, baudrate)
 
     _, protocol = await zigpy.serial.create_serial_connection(
         loop=loop,

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -64,7 +64,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """Disconnect from the zigbee module."""
         if self._api is not None:
             try:
-                await self._api.reset()
+                await self._api.reset(wait_for_reset=False)
             except Exception:
                 LOGGER.debug(
                     "Failed to reset API during disconnect", exc_info=True

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -256,12 +256,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def _form_network(self, network_info, node_info):
         """Clear the current config and forms a new network."""
+        channel_mask = t.Channels.from_channel_list([network_info.channel])
+
         await self._api.request(
             request=c.NWK.Formation.Req(
                 TSN=self.get_sequence(),
                 ChannelList=t_zboss.ChannelEntryList([
-                    t_zboss.ChannelEntry(
-                        page=0, channel_mask=network_info.channel_mask)
+                    t_zboss.ChannelEntry(page=0, channel_mask=channel_mask)
                 ]),
                 ScanDuration=0x05,
                 DistributedNetFlag=0x00,

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -439,8 +439,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def reset_network_info(self) -> None:
         """Reset node network information and leaves the current network."""
-        assert self._api is not None
-        await self._api.reset(option=t_zboss.ResetOptions.FactoryReset)
+        await self._api.request(
+            c.NcpConfig.EraseNVRAM.Req(TSN=self.get_sequence())
+        )
 
     async def start_without_formation(self):
         """Start the network with settings currently stored on the module."""

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -40,7 +40,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """Initialize instance."""
         super().__init__(config=zigpy.config.ZIGPY_SCHEMA(config))
         self._api: ZBOSS | None = None
-        self._reset_task = None
         self.version = None
 
     async def connect(self):
@@ -64,8 +63,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def disconnect(self):
         """Disconnect from the zigbee module."""
-        if self._reset_task and not self._reset_task.done():
-            self._reset_task.cancel()
         if self._api is not None:
             try:
                 await self._api.reset()

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -409,7 +409,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
                 t_zboss.DatasetId.ZB_NVRAM_ADDR_MAP,
                 t_zboss.DSNwkAddrMap
             )
-        for rec in map:
+        for rec in (map or []):
             if rec.nwk_addr == 0x0000:
                 continue
             if rec.ieee_addr not in self.state.network_info.children:
@@ -420,7 +420,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             t_zboss.DatasetId.ZB_NVRAM_APS_SECURE_DATA,
             t_zboss.DSApsSecureKeys
         )
-        for key_entry in keys:
+        for key_entry in (keys or []):
             zigpy_key = zigpy.state.Key(
                 key=t.KeyData(key_entry.key),
                 partner_ieee=key_entry.ieee_addr

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -478,28 +478,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """Shortcut property to access the ZBOSS radio config."""
         return self.config[conf.CONF_ZBOSS_CONFIG]
 
-    @classmethod
-    async def probe(
-            cls, device_config: dict[str, Any]) -> bool | dict[str, Any]:
-        """Probe the NCP.
-
-        Checks whether the NCP device is responding to requests.
-        """
-        config = cls.SCHEMA(
-            {conf.CONF_DEVICE: cls.SCHEMA_DEVICE(device_config)})
-        zboss = ZBOSS(config)
-        try:
-            await zboss.connect()
-            async with async_timeout.timeout(PROBE_TIMEOUT):
-                await zboss.request(
-                    c.NcpConfig.GetZigbeeRole.Req(TSN=1), timeout=1)
-        except asyncio.TimeoutError:
-            return False
-        else:
-            return device_config
-        finally:
-            zboss.close()
-
     async def _watchdog_feed(self):
         """Watchdog loop to periodically test if ZBOSS is still running."""
         await self._api.request(

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -40,7 +40,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """Initialize instance."""
         super().__init__(config=zigpy.config.ZIGPY_SCHEMA(config))
         self._api: ZBOSS | None = None
-        self.version = None
 
     async def connect(self):
         """Connect to the zigbee module."""
@@ -80,8 +79,6 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             await self.load_network_info()
 
         await self.start_without_formation()
-
-        self.version = await self._api.version()
 
         await self.register_endpoints()
 
@@ -325,6 +322,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             TSN=self.get_sequence()
         ))
         self.state.node_info.nwk = res.NWKAddr
+
+        fw_ver, stack_ver, proto_ver = await self._api.version()
+
+        # TODO: is there a way to read the coordinator model and manufacturer?
+        self.state.node_info.model = "ZBOSS"
+        self.state.node_info.manufacturer = "DSR"
+        self.state.node_info.version = f"{fw_ver} (stack {stack_ver})"
 
         res = await self._api.request(
             c.NcpConfig.GetLocalIEEE.Req(

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -211,59 +211,35 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
         )
 
-        await self._api.request(
-            request=c.NcpConfig.SetTCPolicy.Req(
-                TSN=self.get_sequence(),
-                PolicyType=t_zboss.PolicyType.TC_Link_Keys_Required,
-                PolicyValue=zboss_stack_specific[
-                    "tc_policy"]["unique_tclk_required"]
+        for policy_type, policy_value in {
+            t_zboss.PolicyType.TC_Link_Keys_Required: (
+                zboss_stack_specific["tc_policy"]["unique_tclk_required"]
+            ),
+            t_zboss.PolicyType.IC_Required: (
+                zboss_stack_specific["tc_policy"]["ic_required"]
+            ),
+            t_zboss.PolicyType.TC_Rejoin_Enabled: (
+                zboss_stack_specific["tc_policy"]["tc_rejoin_enabled"]
+            ),
+            t_zboss.PolicyType.Ignore_TC_Rejoin: (
+                zboss_stack_specific["tc_policy"]["tc_rejoin_ignored"]
+            ),
+            t_zboss.PolicyType.APS_Insecure_Join: (
+                zboss_stack_specific["tc_policy"]["aps_insecure_join_enabled"]
+            ),
+            t_zboss.PolicyType.Disable_NWK_MGMT_Channel_Update: (
+                zboss_stack_specific["tc_policy"][
+                    "mgmt_channel_update_disabled"
+                ]
+            ),
+        }.items():
+            await self._api.request(
+                request=c.NcpConfig.SetTCPolicy.Req(
+                    TSN=self.get_sequence(),
+                    PolicyType=policy_type,
+                    PolicyValue=policy_value,
+                )
             )
-        )
-
-        await self._api.request(
-            request=c.NcpConfig.SetTCPolicy.Req(
-                TSN=self.get_sequence(),
-                PolicyType=t_zboss.PolicyType.IC_Required,
-                PolicyValue=zboss_stack_specific[
-                    "tc_policy"]["ic_required"]
-            )
-        )
-
-        await self._api.request(
-            request=c.NcpConfig.SetTCPolicy.Req(
-                TSN=self.get_sequence(),
-                PolicyType=t_zboss.PolicyType.TC_Rejoin_Enabled,
-                PolicyValue=zboss_stack_specific[
-                    "tc_policy"]["tc_rejoin_enabled"]
-            )
-        )
-
-        await self._api.request(
-            request=c.NcpConfig.SetTCPolicy.Req(
-                TSN=self.get_sequence(),
-                PolicyType=t_zboss.PolicyType.Ignore_TC_Rejoin,
-                PolicyValue=zboss_stack_specific[
-                    "tc_policy"]["tc_rejoin_ignored"]
-            )
-        )
-
-        await self._api.request(
-            request=c.NcpConfig.SetTCPolicy.Req(
-                TSN=self.get_sequence(),
-                PolicyType=t_zboss.PolicyType.APS_Insecure_Join,
-                PolicyValue=zboss_stack_specific[
-                    "tc_policy"]["aps_insecure_join_enabled"]
-            )
-        )
-
-        await self._api.request(
-            request=c.NcpConfig.SetTCPolicy.Req(
-                TSN=self.get_sequence(),
-                PolicyType=t_zboss.PolicyType.Disable_NWK_MGMT_Channel_Update,
-                PolicyValue=zboss_stack_specific[
-                    "tc_policy"]["mgmt_channel_update_disabled"]
-            )
-        )
 
         await self._form_network(network_info, node_info)
 

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -1,12 +1,12 @@
 """ControllerApplication for ZBOSS NCP protocol based adapters."""
-import asyncio
+from __future__ import annotations
+
 import logging
 import zigpy.util
 import zigpy.state
 import zigpy.appdb
 import zigpy.config
 import zigpy.device
-import async_timeout
 import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.types as t
@@ -596,18 +596,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         """NCP_RESET.indication handler."""
         if msg.ResetSrc == t_zboss.ResetSource.RESET_SRC_POWER_ON:
             return
-        LOGGER.debug(
-            f"Resetting ControllerApplication. Source: {msg.ResetSrc}")
-        if self._reset_task:
-            LOGGER.debug("Preempting ControllerApplication reset")
-            self._reset_task.cancel()
 
-        self._reset_task = asyncio.create_task(self._reset_controller())
-
-    async def _reset_controller(self):
-        """Restart the application controller."""
-        self.disconnect()
-        await self.startup()
+        self.connection_lost(RuntimeError(msg))
 
     async def send_packet(self, packet: t.ZigbeePacket) -> None:
         """Send packets."""

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -357,10 +357,16 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             t_zboss.DatasetId.ZB_IB_COUNTERS,
             t_zboss.DSIbCounters
         )
-        if common and counters:
+
+        # Counters NVRAM dataset can be missing if we don't use the network
+        tx_counter = 0
+        if counters is not None:
+            tx_counter = counters.nib_counter
+
+        if common is not None:
             self.state.network_info.network_key = zigpy.state.Key(
                 key=common.nwk_key,
-                tx_counter=counters.nib_counter,
+                tx_counter=tx_counter,
                 rx_counter=0,
                 seq=common.nwk_key_seq,
                 partner_ieee=self.state.node_info.ieee,

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -440,9 +440,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def reset_network_info(self) -> None:
         """Reset node network information and leaves the current network."""
-        await self._api.request(
-            c.NcpConfig.EraseNVRAM.Req(TSN=self.get_sequence())
-        )
+        assert self._api is not None
+        await self._api.reset(option=t_zboss.ResetOptions.FactoryReset)
 
     async def start_without_formation(self):
         """Start the network with settings currently stored on the module."""

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -67,7 +67,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if self._reset_task and not self._reset_task.done():
             self._reset_task.cancel()
         if self._api is not None:
-            await self._api.reset()
+            try:
+                await self._api.reset()
+            except Exception:
+                LOGGER.debug(
+                    "Failed to reset API during disconnect", exc_info=True
+                )
+
             self._api.close()
             self._api = None
 


### PR DESCRIPTION
This is a fairly large and disorganized PR to get the radio library working with zigpy-cli and ZHA. Main changes are:

1. Remove `probe`, as zigpy now handles this by trying to `connect`.
2. Remove all reconnection logic from the radio library. This is now handled by ZHA (or the upstream application).
3. Load coordinator info, if possible, into `node_info.model` and `node_info.manufacturer`.
4. Get `api.reset()` working properly by internally handling reconnection to the UART.
5. Make sure network formation is completely stable:
   - `reset`, `form`, then `backup` should erase the old network completely and form a new one with random settings.
   - Running `reset` and `form` again will erase them, like before.
   - Running `restore` should bring back the *old* settings exactly: `diff backup1.json backup2.json` should differ only by the `backup_time` and NWK frame counter, everything else should be identical.
6. Logging cleanup. I've moved listener-related messages to a separate logger, as otherwise the CLI was unreadably verbose.

A few things are left:

1. Allow overriding the manufacturer code during joining so that new Aqara devices stay on the network: https://github.com/zigpy/bellows/blob/eae32eaf1158e0b9a6180e9b400f350ac96975a9/bellows/zigbee/application.py#L63-L66 (this should probably be moved to zigpy)
2. Write unit tests so that any changes to zigpy can be tested against this library without having to run it.
3. Replace `zboss.types.basic`, etc. with `zigpy.types.basic`: we want all radio libraries to use zigpy types wherever possible.
4. Migrate to the zigpy `pre-commit` hooks so that auto code formatting works again.
5. Run it for a few weeks on a production network to see if anything breaks 😄.

This radio library is looking really nice, the ZBOSS serial protocol and command set looks extensive and well-designed!