### PR TITLE
Update README.mdUpdate README.md to mention the new external zha library

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,25 @@ Also see:
 
 # Related projects
 
+### zigpy organization
+
+[ziggpy "organization"](https://github.com/zigpy) is the umbrella organization on GitHub that contains all the ZHA and zigpy related projects. For more development documentation/information and discussions between developers please see the main "zigpy" repository ther
+
 ### zigpy
 **[zigpy](https://github.com/zigpy/zigpy)** is a **[Zigbee protocol stack](https://en.wikipedia.org/wiki/Zigbee)** integration project to implement the **[Zigbee Home Automation](https://www.zigbee.org/)** standard as a Python library. Zigbee Home Automation integration with zigpy allows you to connect one of many off-the-shelf Zigbee adapters using one of the available Zigbee radio library modules compatible with zigpy to control Zigbee devices. There is currently support for controlling Zigbee device types such as binary sensors (e.g. motion and door sensors), analog sensors (e.g. temperature sensors), lightbulbs, switches, and fans. Zigpy is tightly integrated with **[Home Assistant](https://www.home-assistant.io)**'s **[ZHA component](https://www.home-assistant.io/components/zha/)** and provides a user-friendly interface for working with a Zigbee network.
 
 ### zigpy-cli (zigpy command line interface)
 [zigpy-cli](https://github.com/zigpy/zigpy-cli) is a unified command line interface for zigpy radios. The goal of this project is to allow low-level network management from an intuitive command line interface and to group useful Zigbee tools into a single binary.
 
+### ZHA - Zigbee Gateway library using zigpy
+
+[ZHA (library)](https://github.com/zigpy/zha) is a high-level Zigbee Gateway class library written in Python and depends on the zigpy project + all of its libraries. This zha library is meant to be used by application-level implementations such as the ZHA integration in Home Assistant. It could potentially also be used to create a stand-alone Zigbee Gateway application and/or other Zigbee host integrations.
+
 ### ZHA Device Handlers
 ZHA deviation handling in Home Assistant relies on the third-party [ZHA Device Handlers](https://github.com/zigpy/zha-device-handlers) project (also known unders zha-quirks package name on PyPI). Zigbee devices that deviate from or do not fully conform to the standard specifications set by the [Zigbee Alliance](https://www.zigbee.org) may require the development of custom [ZHA Device Handlers](https://github.com/zigpy/zha-device-handlers) (ZHA custom quirks handler implementation) to for all their functions to work properly with the ZHA component in Home Assistant. These ZHA Device Handlers for Home Assistant can thus be used to parse custom messages to and from non-compliant Zigbee devices. The custom quirks implementations for zigpy implemented as ZHA Device Handlers for Home Assistant are a similar concept to that of [Hub-connected Device Handlers for the SmartThings platform](https://docs.smartthings.com/en/latest/device-type-developers-guide/) as well as that of [zigbee-herdsman converters as used by Zigbee2mqtt](https://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html), meaning they are each virtual representations of a physical device that expose additional functionality that is not provided out-of-the-box by the existing integration between these platforms.
 
 ### ZHA integration component for Home Assistant
-[ZHA integration component for Home Assistant](https://www.home-assistant.io/integrations/zha/) is a reference implementation of the zigpy library as integrated into the core of **[Home Assistant](https://www.home-assistant.io)** (a Python based open source home automation software). There are also other GUI and non-GUI projects for Home Assistant's ZHA components which builds on or depends on its features and functions to enhance or improve its user-experience, some of those are listed and linked below.
+[ZHA integration component for Home Assistant](https://www.home-assistant.io/integrations/zha/) is a reference implementation of the ZHA Zigbee Gateway library, depending on all the zigpy organization's Zigbee framework libraries and integrated into the core of **[Home Assistant](https://www.home-assistant.io)** (a Python based open source home automation software). There are also other GUI and non-GUI projects for Home Assistant's ZHA components which builds on or depends on its features and functions to enhance or improve its user-experience, some of those are listed and linked below.
 
 #### ZHA Toolkit
 [ZHA Toolkit](https://github.com/mdeweerd/zha-toolkit) is a custom service for "rare" Zigbee operations using the [ZHA integration component](https://www.home-assistant.io/integrations/zha) in [Home Assistant](https://www.home-assistant.io/). The purpose of ZHA Toolkit and its Home Assistant 'Services' feature, is to provide direct control over low level zigbee commands provided in ZHA or zigpy that are not otherwise available or too limited for some use cases. ZHA Toolkit can also; serve as a framework to do local low level coding (the modules are reloaded on each call), provide access to some higher level commands such as ZNP backup (and restore), make it easier to perform one-time operations where (some) Zigbee knowledge is sufficient and avoiding the need to understand the inner workings of ZHA or Zigpy (methods, quirks, etc).


### PR DESCRIPTION
Update README.md to mention the [new external zha library](https://github.com/zigpy/zha) that has been split out of [ZHA integration in Home Assistant's core](https://github.com/home-assistant/core/tree/dev/homeassistant/components/zha).

* https://github.com/zigpy/zha

References;

- https://community.home-assistant.io/t/zigpy-developer-s-begun-work-on-external-and-stand-alone-implementations-of-zha/709912/
- https://rc.home-assistant.io/blog/2024/07/31/release-20248/#zigbee-home-automation-zha-updates
- https://github.com/home-assistant/core/pull/120190
- https://github.com/zigpy/zha/pull/6
- https://github.com/zigpy/zigpy/discussions/1207

FYI, the new external zha library is a high-level Zigbee Gateway library written in Python and depends on the [zigpy](https://github.com/zigpy/zigpy) project + all of its libraries.

This new external zha library is meant to be used by application-level implementions such as the [Zigbee Home Automation integration)](https://www.home-assistant.io/integrations/zha/) in Home Assistant.

Back-story is that this new zha class library started as an initial migration of the core logic from [ZHA integration](https://www.home-assistant.io/integrations/zha) to breakout and move the Zigbee Gateway part away from the [zha inetgration component inside Home Assistant's core repository](https://github.com/home-assistant/core/tree/dev/homeassistant/components/zha) into a self-contained external library. 

The end result of this split (and other further changes to come) should be a huge improvement in terms of code quality in both the Home Assistant half and the library half of zha.

The ultimate goal of having zha as a separate library is to eventually make ZHA reusable outside of Home Assistant, easier to understand, and pave the path to a more streamlined model for contributing device support code to ZHA and Home Assistant (when necessary).

Note that this is an initial pass where the aim was to modify as little as possible in this split. Future changes will hopefully enable zha to work with other stand-alone applications as well.

You will notice that the terminology currently in use within the library (and thus the rewritten integration) mirrors that of Core. This is intentional and will diverge as we see fit.