### PR TITLE
fix: keep .name accessor + start_network nwk-check working under current zigpy/serialx

### DIFF
--- a/zigpy_zboss/uart.py
+++ b/zigpy_zboss/uart.py
@@ -52,8 +52,13 @@ class ZbossNcpProtocol(asyncio.Protocol):
 
     @property
     def name(self) -> str:
-        """Return serial name."""
-        return self._transport.serial.name
+        """Return serial name.
+
+        `serialx.LinuxSerial` (which zigpy.serial uses under recent zigpy)
+        exposes ``port`` rather than ``name``. Fall back gracefully.
+        """
+        ser = self._transport.serial
+        return getattr(ser, "name", getattr(ser, "port", "<unnamed>"))
 
     @property
     def baudrate(self) -> int:
@@ -74,7 +79,7 @@ class ZbossNcpProtocol(asyncio.Protocol):
             self, transport: asyncio.BaseTransport) -> None:
         """Notify serial port opened."""
         self._transport = transport
-        message = f"Opened {transport.serial.name} serial port"
+        message = f"Opened {getattr(transport.serial, 'name', getattr(transport.serial, 'port', '<unnamed>'))} serial port"
         if self._reset_flag:
             self._reset_flag = False
             return

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -78,7 +78,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def start_network(self):
         """Start the network."""
-        if self.state.node_info == zigpy.state.NodeInfo():
+        # The original equality check ``if self.state.node_info == NodeInfo()``
+        # short-circuits when ``form_network`` has populated some fields of
+        # node_info (typically ieee and logical_type) but not ``nwk``. The
+        # ZbossCoordinator construction below then crashes with
+        # ``TypeError: int() argument must be a string, a bytes-like object
+        # or a real number, not 'NoneType'``. Trigger ``load_network_info``
+        # whenever ``nwk`` is missing instead. ``load_network_info`` itself
+        # calls ``GetShortAddr`` which fills it in.
+        if self.state.node_info.nwk is None:
             await self.load_network_info()
 
         await self.start_without_formation()


### PR DESCRIPTION
Two narrow fixes that prevent any current `pip install zigpy-zboss` from
completing a `ControllerApplication.startup()` round against current
`zigpy >= 1.4` + `serialx`. Both are isolated and would land safely
independent of broader zigpy-version-support work.

### 1. `ZbossNcpProtocol.name` against `serialx.LinuxSerial`

The property reads `self._transport.serial.name`. `serialx.LinuxSerial`
(which `zigpy.serial` uses under recent zigpy) does not expose `.name` —
it has `.port`. The original code raises `AttributeError`, which gets
swallowed by the connection-setup path, and the next request raises
`RuntimeError("Coordinator is disconnected, cannot send request")` — a
symptom users hit when trying ZHA with this library today. Fall back
gracefully:

```python
getattr(ser, "name", getattr(ser, "port", "<unnamed>"))
```

Same fix applied to the `connection_made` info-log f-string.

### 2. `start_network` post-formation `node_info.nwk = None`

After `form_network` zigpy populates parts of `state.node_info` (typically
`ieee` and `logical_type`) but not `nwk` — that's normally filled in by
`load_network_info` via `GetShortAddr`. The current condition
`if self.state.node_info == NodeInfo()` short-circuits because node_info
isn't fully empty, so `load_network_info` isn't re-run and
`state.node_info.nwk` stays `None`. The subsequent
`ZbossCoordinator(self, ieee, nwk)` construction then raises:

```
TypeError: int() argument must be a string, a bytes-like object or a real
number, not 'NoneType'
```

Change the trigger condition to be `nwk`-specific so `load_network_info`
runs and populates it.

### Verification

Lab-verified against
[`tostmann/esp-coordinator` v1.1.23](https://github.com/tostmann/esp-coordinator/releases/tag/v1.1.23)
firmware on ESP32-C6 (the firmware-side fix shipped today there is the
matching companion — that release implements `GET_SHORT_ADDRESS` as an NCP
command, without which `load_network_info` couldn't populate `nwk` either).
With this PR's fixes + that firmware, `ControllerApplication.new(auto_form=True)`
now gets through `connect` → `load_network_info` → `form_network` →
`start_network` cleanly:

```
NodeInfo(nwk=0x0000, ieee=68:59:03:fe:ff:04:32:54,
         logical_type=Coordinator, model='ZBOSS', manufacturer='DSR',
         version='1.1.0.23 (stack 3.15.0.0)')
start_network entry: nwk=0x0000  [was: None]
```

### Scope notes

There is additional library-side bit-rot against `zigpy 1.4` (e.g.
`ZbossZDO.Node_Desc_req()` missing the `priority` keyword added in zigpy
1.4) that prevents a fully end-to-end ZHA flow. Those are deliberately
out of scope here — the two fixes in this PR are self-contained and worth
merging on their own. Cross-reference: full context at
[#19](https://github.com/kardia-as/zigpy-zboss/issues/19) — the 2023
"no ESP NCP firmware" blocker is now obsolete; `tostmann/esp-coordinator`
ships ESP32-C6 ZBOSS NCP firmware.

cc @Hedda @puddly @DamKast