### PR TITLE
fix(uart): don't gate URL-style ports on os.path.exists

### DIFF
--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -280,6 +280,42 @@ async def test_connection_lost(dummy_serial_conn, mocker, event_loop):
     assert (await conn_lost_fut) == exception
 
 
+@pytest.mark.asyncio
+async def test_connect_url_port_skips_path_check(mocker, event_loop):
+    """A URL-style port (``socket://``/``tcp://``) has no filesystem path.
+
+    ``connect()`` must not gate on ``os.path.exists`` for such ports, otherwise
+    it spins in the retry loop until the timeout and never opens the connection
+    (regression for ser2net bridges and native-TCP NCPs).
+    """
+    target_url = "socket://127.0.0.1:6638"
+
+    def create_serial_conn(loop, protocol_factory, url, *args, **kwargs):
+        assert url == target_url
+        fut = event_loop.create_future()
+        protocol = protocol_factory()
+        event_loop.add_writer = lambda *a, **k: None
+        event_loop.add_reader = lambda *a, **k: None
+        event_loop.remove_writer = lambda *a, **k: None
+        event_loop.remove_reader = lambda *a, **k: None
+        transport = mocker.Mock()
+        transport.serial = mocker.Mock()
+        protocol.connection_made(transport)
+        fut.set_result((transport, protocol))
+        return fut
+
+    mocker.patch("serialx.create_serial_connection", new=create_serial_conn)
+    # A socket:// path never exists on disk; the check must be skipped for it.
+    exists = mocker.patch("zigpy_zboss.uart.os.path.exists", return_value=False)
+
+    protocol = await zboss_uart.connect(
+        conf.SCHEMA_DEVICE({conf.CONF_DEVICE_PATH: target_url}), api=mocker.Mock()
+    )
+
+    assert protocol is not None
+    exists.assert_not_called()
+
+
 # ToFix: this is not testing the uart test_connection_made method
 # @pytest.mark.asyncio
 # async def test_connection_made(dummy_serial_conn, mocker):

--- a/zigpy_zboss/uart.py
+++ b/zigpy_zboss/uart.py
@@ -288,8 +288,14 @@ async def connect(config: conf.ConfigType, api) -> ZbossNcpProtocol:
     last_exc: OSError | None = None
     protocol = None
 
+    # URL-style ports (``socket://``, ``tcp://``, ``rfc2217://``, …) are not
+    # filesystem paths, so the local-device existence check below must be
+    # skipped for them; otherwise the loop spins until the timeout and the
+    # connection is never opened (e.g. ser2net or a native TCP NCP).
+    is_local_device = "://" not in port
+
     while loop.time() < deadline:
-        if not os.path.exists(port):
+        if is_local_device and not os.path.exists(port):
             await asyncio.sleep(CONNECT_OPEN_RETRY_DELAY)
             continue
 


### PR DESCRIPTION
### Problem

`uart.connect()` polls `os.path.exists(port)` in a retry loop before opening the port, to wait for a hot-plugged local device node to appear. URL-style ports have no filesystem path, so for `socket://…`, `tcp://…`, `rfc2217://…` the check is always `False`: `connect()` spins until `CONNECT_OPEN_TIMEOUT` and then raises `Could not open '…' within 15s` — `serialx.create_serial_connection()` is never even called.

This makes any TCP-attached NCP unusable: ser2net bridges and ESP32-based ZBOSS coordinators exposed over TCP. In ZHA it surfaces as the config entry retrying forever with `[Errno 6] Could not open 'socket://…' within 15s`.

### Fix

Skip the local-device existence check for URL-style ports (`"://" in port`). Real local device paths (`/dev/ttyACM0`, …) keep the hot-plug wait unchanged.

### Test

Added `test_connect_url_port_skips_path_check`: with `os.path.exists` patched to return `False`, `connect("socket://…")` still reaches `serialx.create_serial_connection` and succeeds, and `os.path.exists` is never consulted for the URL. The existing `test_uart.py` suite stays green; `ruff` is clean.

### Verified

Confirmed end-to-end: with this change ZHA (zigpy-zboss 2.0.x) connects to a ZBOSS NCP over a TCP-bridged serial link and completes coordinator init (including a real device join); without it the connection never opens.
