### PR TITLE
Add description and display name for radio metadata support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-    "zigpy>=0.92.0,<2",
+    "zigpy>=0.92.0",
     "serialx",
     "voluptuous",
     "coloredlogs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "jsonschema",
 ]
 
+[project.entry-points."zigpy.radio"]
+zboss = "zigpy_zboss.zigbee.application:ControllerApplication"
+
 [project.optional-dependencies]
 # XXX: The order of these deps seems to matter
 testing = [

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -44,6 +44,8 @@ APS_KEY_ATTR_VERIFIED = 2
 class ControllerApplication(zigpy.application.ControllerApplication):
     """Controller class."""
 
+    DISPLAY_NAME = "ZBOSS"
+    DESCRIPTION = "ZBOSS NCP protocol: nRF52-based, esp32-based modules."
     SCHEMA = CONFIG_SCHEMA
     SCHEMA_DEVICE = SCHEMA_DEVICE
 


### PR DESCRIPTION
Closes #82 

Havn't tested it properly yet, but this would make it possible to add a radio support to zigpy in an easier way. 
That means, no need to update the `zha/application/const.py` file anymore to add the radio to the RadioType enum.

See https://github.com/zigpy/zha/pull/461