### PR TITLE
Fix ZDO quirks

### DIFF
--- a/tests/application/test_bind.py
+++ b/tests/application/test_bind.py
@@ -45,7 +45,7 @@ async def test_bind_req_ieee(make_application):
         responses=[_ok_rsp(c.ZDO.BindReq)],
     )
 
-    status, returned_addr, returned_cluster = await device.zdo.request(
+    (status,) = await device.zdo.request(
         zdo_t.ZDOCmd.Bind_req, SRC_IEEE, 1, 6, dst_address
     )
 
@@ -60,8 +60,6 @@ async def test_bind_req_ieee(make_application):
     assert received.TargetNwkAddr == device.nwk
 
     assert status == zdo_t.Status.SUCCESS
-    assert returned_addr is dst_address
-    assert returned_cluster == 6
 
     await app.shutdown()
 
@@ -87,7 +85,7 @@ async def test_unbind_req_ieee(make_application):
         responses=[_ok_rsp(c.ZDO.UnbindReq)],
     )
 
-    status, returned_addr, returned_cluster = await device.zdo.request(
+    (status,) = await device.zdo.request(
         zdo_t.ZDOCmd.Unbind_req, SRC_IEEE, 1, 6, dst_address
     )
 
@@ -103,8 +101,6 @@ async def test_unbind_req_ieee(make_application):
     assert received.TargetNwkAddr == device.nwk
 
     assert status == zdo_t.Status.SUCCESS
-    assert returned_addr is dst_address
-    assert returned_cluster == 6
 
     await app.shutdown()
 
@@ -117,7 +113,6 @@ async def test_bind_req_group(make_application):
     dst_address = zdo_t.MultiAddress(
         addrmode=zigpy_t.AddrMode.Group,
         nwk=0x1234,
-        endpoint=0,
     )
 
     bind_req = zboss_server.reply_once_to(
@@ -125,7 +120,7 @@ async def test_bind_req_group(make_application):
         responses=[_ok_rsp(c.ZDO.BindReq)],
     )
 
-    status, _, _ = await device.zdo.request(
+    (status,) = await device.zdo.request(
         zdo_t.ZDOCmd.Bind_req, SRC_IEEE, 1, 6, dst_address
     )
 
@@ -147,7 +142,6 @@ async def test_unbind_req_group(make_application):
     dst_address = zdo_t.MultiAddress(
         addrmode=zigpy_t.AddrMode.Group,
         nwk=0x1234,
-        endpoint=0,
     )
 
     unbind_req = zboss_server.reply_once_to(
@@ -155,7 +149,7 @@ async def test_unbind_req_group(make_application):
         responses=[_ok_rsp(c.ZDO.UnbindReq)],
     )
 
-    status, _, _ = await device.zdo.request(
+    (status,) = await device.zdo.request(
         zdo_t.ZDOCmd.Unbind_req, SRC_IEEE, 1, 6, dst_address
     )
 
@@ -189,12 +183,10 @@ async def test_unbind_req_failure_status(make_application):
         )],
     )
 
-    status, returned_addr, returned_cluster = await device.zdo.request(
+    (status,) = await device.zdo.request(
         zdo_t.ZDOCmd.Unbind_req, SRC_IEEE, 1, 6, dst_address
     )
 
     assert status == error_code
-    assert returned_addr is dst_address
-    assert returned_cluster == 6
 
     await app.shutdown()

--- a/tests/application/test_join.py
+++ b/tests/application/test_join.py
@@ -134,3 +134,219 @@ async def test_on_zdo_device_join(make_application, mocker):
     )
 
     await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_on_dev_update_unsecured_join_defers(make_application, mocker):
+    """An unsecured join must not start the interview.
+
+    The device has only associated at that point: it has no network key and
+    cannot answer, so the interview has to wait until it is really on the
+    network.
+    """
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    mocker.patch.object(app, "handle_join", wraps=app.handle_join)
+
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+
+    await zboss_server.send(
+        c.ZDO.DevUpdateInd.Ind(
+            IEEE=ieee,
+            Nwk=0xABCD,
+            Status=t.DeviceUpdateStatus.unsecured_join,
+        )
+    )
+
+    await asyncio.sleep(0.1)
+
+    app.handle_join.assert_not_called()
+    assert ieee not in app.devices
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_on_dev_authorized_joins(make_application, mocker):
+    """Authorization has to be able to bring a device in on its own.
+
+    `Device_annce` is a broadcast and can be lost, so it cannot be the only
+    signal that starts the interview.
+    """
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    mocker.patch.object(app, "handle_join", wraps=app.handle_join)
+
+    nwk = 0xABCD
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+
+    await zboss_server.send(
+        c.ZDO.DevAuthorizedInd.Ind(
+            IEEE=ieee,
+            Nwk=nwk,
+            AuthorizationType=t.uint8_t(1),
+            AuthorizationStatus=t.uint8_t(0),
+        )
+    )
+
+    await asyncio.sleep(0.1)
+
+    app.handle_join.assert_called_once_with(nwk, ieee, 0x0000)
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_announcement_then_authorization_interviews_once(
+        make_application, mocker):
+    """Both join signals normally fire; only one may start the interview.
+
+    `schedule_initialize` cancels and restarts any interview already
+    running, so the authorization must not step in once the announcement
+    has been handled.
+    """
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    schedule_initialize = mocker.patch.object(
+        zigpy.device.Device, "schedule_initialize", autospec=True
+    )
+
+    nwk = 0xABCD
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+
+    await zboss_server.send(
+        c.ZDO.DevAnnceInd.Ind(NWK=nwk, IEEE=ieee, MacCap=t.uint8_t(0x8E))
+    )
+    await zboss_server.send(
+        c.ZDO.DevAuthorizedInd.Ind(
+            IEEE=ieee,
+            Nwk=nwk,
+            AuthorizationType=t.uint8_t(1),
+            AuthorizationStatus=t.uint8_t(0),
+        )
+    )
+
+    await asyncio.sleep(0.1)
+
+    assert schedule_initialize.call_count == 1
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_on_dev_authorized_updates_stale_address(
+        make_application, mocker):
+    """A lost announcement must not leave the device at its old address."""
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+    app.add_initialized_device(ieee=ieee, nwk=0x1111)
+
+    mocker.patch.object(zigpy.device.Device, "schedule_initialize")
+
+    await zboss_server.send(
+        c.ZDO.DevAuthorizedInd.Ind(
+            IEEE=ieee,
+            Nwk=0xABCD,
+            AuthorizationType=t.uint8_t(1),
+            AuthorizationStatus=t.uint8_t(0),
+        )
+    )
+
+    await asyncio.sleep(0.1)
+
+    assert app.devices[ieee].nwk == 0xABCD
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_announcement_does_not_restart_interview(
+        make_application, mocker):
+    """Routers rebroadcast `Device_annce`, so it arrives more than once.
+
+    Every repeat would otherwise cancel the running interview and start it
+    again from scratch.
+    """
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    # Leaving this mocked keeps the device un-initialized, standing in for
+    # an interview that is still running.
+    schedule_initialize = mocker.patch.object(
+        zigpy.device.Device, "schedule_initialize"
+    )
+
+    nwk = 0xABCD
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+    announcement = c.ZDO.DevAnnceInd.Ind(
+        NWK=nwk, IEEE=ieee, MacCap=t.uint8_t(0x8E)
+    )
+
+    await zboss_server.send(announcement)
+    await zboss_server.send(announcement)
+    await zboss_server.send(announcement)
+
+    await asyncio.sleep(0.1)
+
+    assert schedule_initialize.call_count == 1
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_announcement_at_new_address_restarts_interview(
+        make_application, mocker):
+    """A device that moved has to be re-interviewed at its new address."""
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    schedule_initialize = mocker.patch.object(
+        zigpy.device.Device, "schedule_initialize"
+    )
+
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+
+    await zboss_server.send(
+        c.ZDO.DevAnnceInd.Ind(NWK=0xABCD, IEEE=ieee, MacCap=t.uint8_t(0x8E))
+    )
+    await zboss_server.send(
+        c.ZDO.DevAnnceInd.Ind(NWK=0xBEEF, IEEE=ieee, MacCap=t.uint8_t(0x8E))
+    )
+
+    await asyncio.sleep(0.1)
+
+    assert schedule_initialize.call_count == 2
+    assert app.devices[ieee].nwk == 0xBEEF
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_announcement_for_initialized_device_is_handled(
+        make_application, mocker):
+    """An initialized device rejoining still has to reach zigpy."""
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    nwk = 0xABCD
+    ieee = t.EUI64.convert("11:22:33:44:55:66:77:88")
+    app.add_initialized_device(ieee=ieee, nwk=nwk)
+
+    mocker.patch.object(app, "handle_join", wraps=app.handle_join)
+
+    await zboss_server.send(
+        c.ZDO.DevAnnceInd.Ind(NWK=nwk, IEEE=ieee, MacCap=t.uint8_t(0x8E))
+    )
+
+    await asyncio.sleep(0.1)
+
+    app.handle_join.assert_called_once_with(
+        nwk=nwk, ieee=ieee, parent_nwk=None
+    )
+
+    await app.shutdown()

--- a/tests/application/test_join.py
+++ b/tests/application/test_join.py
@@ -78,7 +78,9 @@ async def test_join_coordinator(make_application):
 async def test_join_device(make_application):
     """Test device join."""
     ieee = t.EUI64.convert("EC:1B:BD:FF:FE:54:4F:40")
-    nwk = 0x1234
+    # Not 0x1234: that is the coordinator's own NWK in the test server, and
+    # `get_device()` resolves it to the coordinator instead of this device.
+    nwk = 0xABCD
 
     app, zboss_server = make_application(server_cls=BaseZbossDevice)
     app.add_initialized_device(ieee=ieee, nwk=nwk)

--- a/tests/application/test_quirked_zdo.py
+++ b/tests/application/test_quirked_zdo.py
@@ -1,0 +1,307 @@
+"""Test that ZDO requests behave the same with and without a quirk.
+
+`zigpy.quirks.get_device()` returns a plain `zigpy.device.Device` subclass,
+so a quirked device cannot carry any `ZbossZDO` method overrides. Every ZDO
+request is therefore translated on the outgoing packet instead, and both
+kinds of device must end up sending the same NCP command and returning the
+same value.
+"""
+import pytest
+import zigpy.endpoint
+import zigpy.exceptions
+import zigpy.quirks
+import zigpy.types as zigpy_t
+import zigpy.zdo
+import zigpy.zdo.types as zdo_t
+
+import zigpy_zboss.commands as c
+import zigpy_zboss.types as t
+from zigpy_zboss.zigbee.device import ZbossZDO
+
+from ..conftest import BaseZbossDevice
+
+DEVICE_IEEE = t.EUI64.convert("18:7a:3e:ff:fe:7d:13:85")
+DEVICE_NWK = 0xF79F
+
+# Both device kinds are exercised by every test: without a quirk the device
+# is a ZbossDevice, with one it is a plain zigpy device.
+quirked = pytest.mark.parametrize("quirked", [False, True])
+
+
+def _ok_rsp(cmd, **kwargs):
+    """Build a successful response for a ZBOSS ZDO command."""
+    return cmd.Rsp(
+        TSN=123,
+        StatusCat=t.StatusCategory(1),
+        StatusCode=t.StatusCodeGeneric.OK,
+        **kwargs,
+    )
+
+
+async def _start(make_application, quirked):
+    """Start an application with one device, quirked or not."""
+    app, zboss_server = make_application(BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    device = app.add_initialized_device(ieee=DEVICE_IEEE, nwk=DEVICE_NWK)
+
+    if quirked:
+        device = zigpy.quirks.CustomDevice(
+            app, device.ieee, device.nwk, device
+        )
+        app.devices[device.ieee] = device
+        device.add_endpoint(1).status = zigpy.endpoint.Status.ZDO_INIT
+
+    device.endpoints[1].add_input_cluster(6)
+
+    assert isinstance(device.zdo, ZbossZDO) is not quirked
+
+    return app, zboss_server, device
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_bind(make_application, quirked):
+    """Binding sends a BindReq and returns the standard ZDO response."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    bind_req = zboss_server.reply_once_to(
+        request=c.ZDO.BindReq.Req(TSN=123, partial=True),
+        responses=[_ok_rsp(c.ZDO.BindReq)],
+    )
+
+    result = await device.endpoints[1].on_off.bind()
+
+    received = await bind_req
+
+    assert received.TargetNwkAddr == DEVICE_NWK
+    assert received.SrcIEEE == DEVICE_IEEE
+    assert received.SrcEndpoint == 1
+    assert received.ClusterId == 6
+    assert received.DstAddrMode == t.BindAddrMode.IEEE
+    assert result == [zdo_t.Status.SUCCESS]
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_unbind(make_application, quirked):
+    """Unbinding sends an UnbindReq and returns the standard response."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    unbind_req = zboss_server.reply_once_to(
+        request=c.ZDO.UnbindReq.Req(TSN=123, partial=True),
+        responses=[_ok_rsp(c.ZDO.UnbindReq)],
+    )
+
+    result = await device.endpoints[1].on_off.unbind()
+
+    received = await unbind_req
+
+    assert received.ClusterId == 6
+    assert result == [zdo_t.Status.SUCCESS]
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_bind_failure_status(make_application, quirked):
+    """A non-zero NCP status is reported back to the caller."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    zboss_server.reply_once_to(
+        request=c.ZDO.BindReq.Req(TSN=123, partial=True),
+        responses=[
+            c.ZDO.BindReq.Rsp(
+                TSN=123,
+                StatusCat=t.StatusCategory(1),
+                StatusCode=t.StatusCodeGeneric.ERROR,
+            )
+        ],
+    )
+
+    (status,) = await device.endpoints[1].on_off.bind()
+
+    assert status != zdo_t.Status.SUCCESS
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_bind_to_group(make_application, quirked):
+    """A group destination is packed into the first two DstAddr bytes."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    bind_req = zboss_server.reply_once_to(
+        request=c.ZDO.BindReq.Req(TSN=123, partial=True),
+        responses=[_ok_rsp(c.ZDO.BindReq)],
+    )
+
+    result = await device.zdo.request(
+        zdo_t.ZDOCmd.Bind_req,
+        DEVICE_IEEE,
+        1,
+        6,
+        zdo_t.MultiAddress(addrmode=zigpy_t.AddrMode.Group, nwk=0x1234),
+    )
+
+    received = await bind_req
+
+    assert received.DstAddrMode == t.BindAddrMode.Group
+    assert received.DstAddr == t.EUI64([0x34, 0x12, 0, 0, 0, 0, 0, 0])
+    assert received.DstEndpoint == 0
+    assert result == [zdo_t.Status.SUCCESS]
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_leave(make_application, quirked):
+    """A device can be removed from the network."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    leave_req = zboss_server.reply_once_to(
+        request=c.ZDO.MgtLeave.Req(TSN=123, partial=True),
+        responses=[_ok_rsp(c.ZDO.MgtLeave)],
+    )
+
+    result = await device.zdo.leave()
+
+    received = await leave_req
+
+    assert received.IEEE == DEVICE_IEEE
+    assert received.DestNWK == DEVICE_NWK
+    assert result == [zdo_t.Status.SUCCESS]
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_node_desc(make_application, quirked):
+    """A device can be interviewed."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    node_desc = zdo_t.NodeDescriptor(
+        logical_type=zdo_t.LogicalType.Router,
+        complex_descriptor_available=0,
+        user_descriptor_available=0,
+        reserved=0,
+        aps_flags=0,
+        frequency_band=zdo_t.NodeDescriptor.FrequencyBand.Freq2400MHz,
+        mac_capability_flags=142,
+        manufacturer_code=4190,
+        maximum_buffer_size=82,
+        maximum_incoming_transfer_size=82,
+        server_mask=11264,
+        maximum_outgoing_transfer_size=82,
+        descriptor_capability_field=0,
+    )
+
+    zboss_server.reply_once_to(
+        request=c.ZDO.NodeDescReq.Req(TSN=123, partial=True),
+        responses=[
+            _ok_rsp(
+                c.ZDO.NodeDescReq, NodeDesc=node_desc, NwkAddr=DEVICE_NWK
+            )
+        ],
+    )
+
+    assert await device.get_node_descriptor() == node_desc
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_simple_desc(make_application, quirked):
+    """An endpoint can be interviewed."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    simple_desc = t.SimpleDescriptor(
+        endpoint=1,
+        profile=260,
+        device_type=769,
+        device_version=1,
+        input_clusters_count=3,
+        output_clusters_count=1,
+        input_clusters=[0, 3, 6],
+        output_clusters=[25],
+    )
+
+    zboss_server.reply_once_to(
+        request=c.ZDO.SimpleDescriptorReq.Req(TSN=123, partial=True),
+        responses=[
+            _ok_rsp(
+                c.ZDO.SimpleDescriptorReq,
+                SimpleDesc=simple_desc,
+                NwkAddr=DEVICE_NWK,
+            )
+        ],
+    )
+
+    status, _, desc = await device.zdo.Simple_Desc_req(DEVICE_NWK, 1)
+
+    assert status == zdo_t.Status.SUCCESS
+    assert desc.endpoint == 1
+    assert desc.profile == 260
+    assert list(desc.input_clusters) == [0, 3, 6]
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_lqi(make_application, quirked):
+    """A device's neighbour table can be read."""
+    app, zboss_server, device = await _start(make_application, quirked)
+
+    neighbors = zdo_t.Neighbors(
+        Entries=0, StartIndex=0, NeighborTableList=[]
+    )
+
+    zboss_server.reply_once_to(
+        request=c.ZDO.MgmtLqi.Req(TSN=123, partial=True),
+        responses=[_ok_rsp(c.ZDO.MgmtLqi, Neighbors=neighbors)],
+    )
+
+    status, received = await device.zdo.Mgmt_Lqi_req(0)
+
+    assert status == zdo_t.Status.SUCCESS
+    assert received == neighbors
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_unsupported_unicast_zdo_fails_fast(make_application, quirked):
+    """An untranslatable ZDO request errors instead of silently hanging."""
+    app, _, device = await _start(make_application, quirked)
+
+    with pytest.raises(zigpy.exceptions.DeliveryError):
+        await device.zdo.request(zdo_t.ZDOCmd.Mgmt_Bind_req, 0)
+
+    await app.shutdown()
+
+
+@quirked
+@pytest.mark.asyncio
+async def test_unsupported_zdo_broadcast_is_dropped(make_application, quirked):
+    """Broadcasts have no caller waiting on a reply, so they are dropped."""
+    app, _, _ = await _start(make_application, quirked)
+
+    await zigpy.zdo.broadcast(
+        app,
+        zdo_t.ZDOCmd.Mgmt_Rtg_req,
+        0x0000,
+        0x00,
+        0,
+        broadcast_address=zigpy_t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR,
+    )
+
+    await app.shutdown()

--- a/tests/application/test_zdo_requests.py
+++ b/tests/application/test_zdo_requests.py
@@ -1,14 +1,19 @@
 """Test application ZDO request."""
 import asyncio
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 import zigpy.types as z_types
 import zigpy.zdo.types as zdo_t
+from zigpy.const import APS_REPLY_TIMEOUT_EXTENDED
 
 import zigpy_zboss.commands as c
 import zigpy_zboss.types as t
 
 from ..conftest import BaseZbossDevice
+
+REMOTE_IEEE = t.EUI64.convert("00:11:22:33:44:55:66:77")
+REMOTE_NWK = 0x1234
 
 
 @pytest.mark.asyncio
@@ -83,5 +88,131 @@ async def test_mgmt_nwk_update_req(make_application, mocker):
     await nwk_update_req
 
     assert app.state.network_info.channel == new_channel
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ieee_addr_req_discovery(make_application):
+    """A broadcast IEEE_addr_req is answered on behalf of the remote device."""
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    zboss_server.reply_once_to(
+        request=c.ZDO.IeeeAddrReq.Req(NWKtoMatch=REMOTE_NWK, partial=True),
+        responses=[
+            c.ZDO.IeeeAddrReq.Rsp(
+                TSN=123,
+                StatusCat=t.StatusCategory(1),
+                StatusCode=t.StatusCodeGeneric.OK,
+                RemoteDevIEEE=REMOTE_IEEE,
+                RemoteDevNWK=t.NWK(REMOTE_NWK),
+            )
+        ],
+    )
+
+    app.packet_received = Mock(wraps=app.packet_received)
+
+    await app._discover_unknown_device(t.NWK(REMOTE_NWK))
+
+    (rsp,) = app.packet_received.call_args.args
+
+    assert rsp.cluster_id == zdo_t.ZDOCmd.IEEE_addr_rsp
+    assert rsp.src.address == REMOTE_NWK
+    assert rsp.src_ep == 0
+    assert rsp.dst_ep == 0
+
+    _, args = app._device.zdo.deserialize(
+        zdo_t.ZDOCmd.IEEE_addr_rsp, rsp.data.serialize()
+    )
+    status, ieee, nwk = args[:3]
+
+    assert status == zdo_t.Status.SUCCESS
+    assert ieee == REMOTE_IEEE
+    assert nwk == REMOTE_NWK
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ieee_addr_req_failure(make_application):
+    """A failed IEEE_addr_req is answered with dummy values."""
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+
+    zboss_server.reply_once_to(
+        request=c.ZDO.IeeeAddrReq.Req(NWKtoMatch=REMOTE_NWK, partial=True),
+        responses=[
+            c.ZDO.IeeeAddrReq.Rsp(
+                TSN=123,
+                StatusCat=t.StatusCategory(1),
+                StatusCode=t.StatusCodeGeneric.ERROR,
+                RemoteDevIEEE=REMOTE_IEEE,
+                RemoteDevNWK=t.NWK(REMOTE_NWK),
+            )
+        ],
+    )
+
+    app.packet_received = Mock(wraps=app.packet_received)
+
+    await app._discover_unknown_device(t.NWK(REMOTE_NWK))
+
+    (rsp,) = app.packet_received.call_args.args
+
+    assert rsp.src.address == 0x0000
+
+    _, args = app._device.zdo.deserialize(
+        zdo_t.ZDOCmd.IEEE_addr_rsp, rsp.data.serialize()
+    )
+    status, ieee, nwk = args[:3]
+
+    assert status != zdo_t.Status.SUCCESS
+    assert ieee == t.EUI64([0xFF] * 8)
+    assert nwk == 0xFFFF
+
+    await app.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_zdo_ncp_timeout_does_not_preempt_zigpy(make_application):
+    """The NCP timeout must outlast the longest deadline zigpy will use.
+
+    A ZDO command is only answered once the on-air transaction resolves, so
+    capping it at the NCP default made zigpy's extended window unreachable
+    and turned every request into three.
+    """
+    app, zboss_server = make_application(server_cls=BaseZbossDevice)
+    await app.startup(auto_form=False)
+    app.add_initialized_device(ieee=REMOTE_IEEE, nwk=REMOTE_NWK)
+
+    app._api.request = AsyncMock(
+        return_value=c.ZDO.MgtLeave.Rsp(
+            TSN=1,
+            StatusCat=t.StatusCategory(1),
+            StatusCode=t.StatusCodeGeneric.OK,
+        )
+    )
+
+    await app.send_packet(
+        z_types.ZigbeePacket(
+            src=z_types.AddrModeAddress(
+                addr_mode=z_types.AddrMode.NWK, address=0x0000
+            ),
+            src_ep=0,
+            dst=z_types.AddrModeAddress(
+                addr_mode=z_types.AddrMode.NWK, address=REMOTE_NWK
+            ),
+            dst_ep=0,
+            tsn=1,
+            profile_id=0,
+            cluster_id=zdo_t.ZDOCmd.Mgmt_Leave_req,
+            data=z_types.SerializableBytes(
+                b"\x01" + REMOTE_IEEE.serialize() + b"\x00"
+            ),
+        )
+    )
+
+    timeout = app._api.request.mock_calls[0].kwargs["timeout"]
+    assert timeout >= APS_REPLY_TIMEOUT_EXTENDED
 
     await app.shutdown()

--- a/zigpy_zboss/zigbee/application.py
+++ b/zigpy_zboss/zigbee/application.py
@@ -652,20 +652,42 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         if dev:
             self.handle_leave(nwk=dev.nwk, ieee=msg.IEEE)
 
+    def _should_handle_join(self, nwk: t.NWK, ieee: t.EUI64) -> bool:
+        """Whether a join signal is worth passing on to zigpy.
+
+        `Device_annce` is a broadcast that routers rebroadcast, so the same
+        join arrives several times, and the NCP reports its own indications
+        alongside it. `handle_join` restarts a running interview, so the
+        repeats have to be dropped while one is still in flight.
+        """
+        device = self.devices.get(ieee)
+        return device is None or device.nwk != nwk or device.is_initialized
+
     def on_zdo_device_announcement(self, msg: c.ZDO.DevAnnceInd.Ind):
         """ZDO Device announcement command received."""
-        self.handle_join(nwk=msg.NWK, ieee=msg.IEEE, parent_nwk=None)
+        if self._should_handle_join(msg.NWK, msg.IEEE):
+            self.handle_join(nwk=msg.NWK, ieee=msg.IEEE, parent_nwk=None)
 
     def on_dev_update(self, msg: c.ZDO.DevUpdateInd.Ind):
         """Device update indication."""
         if msg.Status == t_zboss.DeviceUpdateStatus.secured_rejoin:
-            self.handle_join(msg.Nwk, msg.IEEE, 0x0000)
+            if self._should_handle_join(msg.Nwk, msg.IEEE):
+                self.handle_join(msg.Nwk, msg.IEEE, 0x0000)
         elif msg.Status == t_zboss.DeviceUpdateStatus.unsecured_join:
-            self.handle_join(msg.Nwk, msg.IEEE, 0x0000)
+            # A fresh association: the device has no network key yet and
+            # cannot answer, so interviewing it now only adds traffic while
+            # it is still finishing the handshake. The announcement or the
+            # authorization indication brings it in once it is really on.
+            LOGGER.debug(
+                "Device %s associated as 0x%04x, waiting for it to join",
+                msg.IEEE,
+                msg.Nwk,
+            )
         elif msg.Status == t_zboss.DeviceUpdateStatus.device_left:
             self.handle_leave(msg.Nwk, msg.IEEE)
         elif msg.Status == t_zboss.DeviceUpdateStatus.tc_rejoin:
-            self.handle_join(msg.Nwk, msg.IEEE, 0x0000)
+            if self._should_handle_join(msg.Nwk, msg.IEEE):
+                self.handle_join(msg.Nwk, msg.IEEE, 0x0000)
 
     def on_dev_authorized(self, msg: c.ZDO.DevAuthorizedInd.Ind):
         """TC device authorized indication."""
@@ -677,6 +699,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             )
             # ZBOSS NCP will kick the device and reset; proactively clean up
             self.handle_leave(msg.Nwk, msg.IEEE)
+            return
+
+        # `Device_annce` is a broadcast and can be lost, while this
+        # indication is generated locally by the NCP, so it has to be able
+        # to bring the device in on its own.
+        if self._should_handle_join(msg.Nwk, msg.IEEE):
+            self.handle_join(msg.Nwk, msg.IEEE, 0x0000)
 
     def on_apsde_indication(self, msg):
         """APSDE-DATA.indication handler."""

--- a/zigpy_zboss/zigbee/device.py
+++ b/zigpy_zboss/zigbee/device.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import zigpy.device
 import zigpy.endpoint
+import zigpy.exceptions
 import zigpy.types as t
 import zigpy.util
 from zigpy.zdo import ZDO as ZigpyZDO
@@ -14,9 +15,23 @@ from zigpy_zboss import commands as c
 
 LOGGER = logging.getLogger(__name__)
 
+# A ZDO command is only answered once the on-air transaction resolves,
+# which takes the NCP up to a minute for an unreachable device. zigpy
+# cancels its own requests long before this, so it is only a backstop
+# for paths that impose no deadline of their own, such as broadcasts.
+ZDO_TIMEOUT = 70
+
 
 class ZbossZDO(ZigpyZDO):
-    """The ZDO endpoint of a ZBOSS device."""
+    """The ZDO endpoint of a ZBOSS device.
+
+    The ZBOSS NCP has no APSDE path for ZDO: every ZDO request has to be sent
+    as its own NCP command. Rather than overriding the individual `*_req`
+    methods, which quirks discard when they replace a device object, the
+    translation happens in `zboss_specific_cmd` on the outgoing packet. That
+    hook lives on the coordinator, which is never quirked, so every device
+    takes the same path and gets standard zigpy return values.
+    """
 
     def handle_mgmt_permit_joining_req(
         self,
@@ -36,185 +51,13 @@ class ZbossZDO(ZigpyZDO):
             (permit_duration, tc_significance),
         )
 
-    async def Bind_req(self, eui64, ep, cluster, dst_address):
-        """Binding request."""
-        if dst_address.addrmode == t.AddrMode.IEEE:
-            addr_mode = t_zboss.BindAddrMode.IEEE
-            dst_eui64 = dst_address.ieee
-        # ZBOSS does not support the NWK mode for binding
-        elif dst_address.addrmode == t.AddrMode.NWK:
-            self.log(
-                logging.WARNING,
-                "Nwk address mode is not supported for the Bind request."
-            )
-        elif dst_address.addrmode == t.AddrMode.Group:
-            addr_mode = t_zboss.BindAddrMode.Group
-            dst_eui64 = [
-                dst_address.nwk % 0x100,
-                dst_address.nwk >> 8,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ]
-
-        res = await self._device._application._api.request(
-            c.ZDO.BindReq.Req(
-                TSN=self._device._application.get_sequence(),
-                TargetNwkAddr=self._device.nwk,
-                SrcIEEE=eui64,
-                SrcEndpoint=ep,
-                ClusterId=cluster,
-                DstAddrMode=addr_mode,
-                DstAddr=dst_eui64,
-                DstEndpoint=dst_address.endpoint,
-            )
-        )
-        if res.StatusCode != 0:
-            return (res.StatusCode, dst_address, cluster)
-
-        return (zdo_t.Status.SUCCESS, dst_address, cluster)
-
-    async def Unbind_req(self, eui64, ep, cluster, dst_address):
-        """Unbinding request."""
-        if dst_address.addrmode == t.AddrMode.IEEE:
-            addr_mode = t_zboss.BindAddrMode.IEEE
-            dst_eui64 = dst_address.ieee
-        # ZBOSS does not support the NWK mode for binding
-        elif dst_address.addrmode == t.AddrMode.NWK:
-            self.log(
-                logging.WARNING,
-                "Nwk address mode is not supported for the Unbind request."
-            )
-        elif dst_address.addrmode == t.AddrMode.Group:
-            addr_mode = t_zboss.BindAddrMode.Group
-            dst_eui64 = [
-                dst_address.nwk % 0x100,
-                dst_address.nwk >> 8,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ]
-
-        res = await self._device._application._api.request(
-            c.ZDO.UnbindReq.Req(
-                TSN=self._device._application.get_sequence(),
-                TargetNwkAddr=self._device.nwk,
-                SrcIEEE=eui64,
-                SrcEndpoint=ep,
-                ClusterId=cluster,
-                DstAddrMode=addr_mode,
-                DstAddr=dst_eui64,
-                DstEndpoint=dst_address.endpoint,
-            )
-        )
-        if res.StatusCode != 0:
-            return (res.StatusCode, dst_address, cluster)
-
-        return (zdo_t.Status.SUCCESS, dst_address, cluster)
-
-    def request(self, command, *args, use_ieee=False):
-        """Request overwrite for Bind/Unbind requests."""
-        if command == zdo_t.ZDOCmd.Bind_req:
-            return self.Bind_req(*args)
-        if command == zdo_t.ZDOCmd.Unbind_req:
-            return self.Unbind_req(*args)
-        return super().request(command, *args, use_ieee=use_ieee)
-
-    async def Node_Desc_req(self, nwk):
-        """Node descriptor request."""
-        res = await self._device._application._api.request(
-            c.ZDO.NodeDescReq.Req(
-                TSN=self._device._application.get_sequence(),
-                NwkAddr=nwk
-            )
-        )
-        if res.StatusCode != 0:
-            return (res.StatusCode, None, None)
-
-        return (zdo_t.Status.SUCCESS, None, res.NodeDesc)
-
-    async def Simple_Desc_req(self, nwk, ep):
-        """Request simple descriptor."""
-        res = await self._device._application._api.request(
-            c.ZDO.SimpleDescriptorReq.Req(
-                TSN=self._device._application.get_sequence(),
-                NwkAddr=nwk,
-                Endpoint=ep
-            )
-        )
-        if res.StatusCode != 0:
-            return (res.StatusCode, None, None)
-
-        desc = zdo_t.SimpleDescriptor(
-            endpoint=res.SimpleDesc.endpoint,
-            profile=res.SimpleDesc.profile,
-            device_type=res.SimpleDesc.device_type,
-            device_version=res.SimpleDesc.device_version,
-            input_clusters=res.SimpleDesc.input_clusters,
-            output_clusters=res.SimpleDesc.output_clusters,
-        )
-
-        return (zdo_t.Status.SUCCESS, None, desc)
-
-    async def Active_EP_req(self, nwk):
-        """Request active end points."""
-        res = await self._device._application._api.request(
-            c.ZDO.ActiveEpReq.Req(
-                TSN=self._device._application.get_sequence(),
-                NwkAddr=nwk
-            )
-        )
-        if res.StatusCode != 0:
-            return (res.StatusCode, None, None)
-
-        return (zdo_t.Status.SUCCESS, None, res.ActiveEpList)
-
-    async def Mgmt_Lqi_req(self, idx):
-        """Request Link Quality Index."""
-        res = await self._device._application._api.request(
-            c.ZDO.MgmtLqi.Req(
-                TSN=self._device._application.get_sequence(),
-                DestNWK=self._device.nwk,
-                Index=idx,
-            )
-        )
-        if res.StatusCode != 0:
-            return (res.StatusCode, None)
-
-        return (res.StatusCode, res.Neighbors)
-
-    async def Mgmt_Leave_req(self, ieee, flags):
-        """Request device leaving the network."""
-        res = await self._device._application._api.request(
-            c.ZDO.MgtLeave.Req(
-                TSN=self._device._application.get_sequence(),
-                DestNWK=t.NWK(self._device._application.devices[ieee].nwk),
-                IEEE=t.EUI64(ieee),
-                Flags=t.uint8_t(flags),
-            )
-        )
-        return res.StatusCode
-
-    async def Mgmt_Permit_Joining_req(self, duration, tc_significance):
-        """Request join permition."""
-        res = await self._device._application._api.request(
-            c.ZDO.PermitJoin.Req(
-                TSN=self._device._application.get_sequence(),
-                DestNWK=t.NWK(t.BroadcastAddress.RX_ON_WHEN_IDLE),
-                PermitDuration=t.uint8_t(duration),
-                TCSignificance=t.uint8_t(tc_significance),
-            )
-        )
-        return res.StatusCode
-
     async def Mgmt_NWK_Update_req(self, nwkUpdate):
-        """Issue a ZDO Mgmt_NWK_Update (energy scan / channel change)."""
+        """Issue a ZDO Mgmt_NWK_Update (energy scan / channel change).
+
+        Kept as an override: an energy scan can take longer than zigpy's APS
+        reply timeout, so it must not go through `Device.request`. It is only
+        ever issued on the coordinator, which quirks never replace.
+        """
         res = await self._device._application._api.request(
             c.ZDO.MgmtNwkUpdate.Req(
                 TSN=self._device._application.get_sequence(),
@@ -233,7 +76,7 @@ class ZbossZDO(ZigpyZDO):
         return (None, res.ScannedChannels, None, None, res.EnergyValues)
 
     async def zboss_specific_cmd(self, packet: t.ZigbeePacket) -> None:
-        """Reroute ZDO packet sent over APSDE to custom ZBOSS ZDO commands."""
+        """Reroute ZDO packets sent over APSDE to ZBOSS ZDO commands."""
         try:
             zdo_hdr, zdo_args = self.deserialize(
                 cluster_id=packet.cluster_id, data=packet.data.serialize()
@@ -242,8 +85,297 @@ class ZbossZDO(ZigpyZDO):
             LOGGER.debug("Could not parse ZDO message from packet")
             return
 
-        if zdo_hdr.command_id == zdo_t.ZDOCmd.IEEE_addr_req:
-            await self._IEEE_addr_req(packet, zdo_hdr, zdo_args)
+        handler = self._ZDO_PACKET_HANDLERS.get(zdo_hdr.command_id)
+
+        if handler is not None:
+            await handler(self, packet, zdo_hdr, zdo_args)
+            return
+
+        is_response = bool(zdo_hdr.command_id & 0x8000)
+        is_unicast = packet.dst.addr_mode in (t.AddrMode.NWK, t.AddrMode.IEEE)
+
+        # Only unicast requests have a caller waiting on a reply. Dropping one
+        # silently would stall that caller until it times out.
+        if is_response or not is_unicast:
+            LOGGER.debug("Dropping unsupported ZDO packet: %r", packet)
+            return
+
+        raise zigpy.exceptions.DeliveryError(
+            f"ZBOSS NCP cannot send ZDO command {zdo_hdr.command_id!r}"
+        )
+
+    @property
+    def _api(self):
+        """Return the NCP API of the application this ZDO belongs to."""
+        return self._device._application._api
+
+    def _next_tsn(self) -> int:
+        """Return the next NCP transmission sequence number."""
+        return self._device._application.get_sequence()
+
+    def _target_nwk(self, packet: t.ZigbeePacket) -> t.NWK:
+        """Return the NWK address a ZDO packet is addressed to."""
+        if packet.dst.addr_mode != t.AddrMode.IEEE:
+            return t.NWK(packet.dst.address)
+
+        try:
+            device = self._device._application.get_device(
+                ieee=packet.dst.address
+            )
+        except KeyError as exc:
+            raise zigpy.exceptions.DeliveryError(
+                f"Cannot send ZDO request to unknown device {packet.dst!r}"
+            ) from exc
+
+        return t.NWK(device.nwk)
+
+    def _send_zdo_rsp(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            *values: Any,
+            src: t.AddrModeAddress | None = None) -> None:
+        """Feed a synthesized ZDO response back into zigpy.
+
+        `src` defaults to the request's destination, which is what zigpy
+        matches the pending request against. Broadcast requests have to
+        override it with the address that actually answered.
+        """
+        rsp_cmd = zdo_t.ZDOCmd(zdo_hdr.command_id | 0x8000)
+        _, schema = zdo_t.CLUSTERS[rsp_cmd]
+
+        args = list(values)
+        while args and args[-1] is None:
+            args.pop()
+
+        data = t.uint8_t(zdo_hdr.tsn).serialize() + t.serialize(args, schema)
+
+        self._device._application.packet_received(
+            t.ZigbeePacket(
+                src=packet.dst if src is None else src,
+                src_ep=0,
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.NWK,
+                    address=t.NWK(0x0000),
+                ),
+                dst_ep=0,
+                tsn=zdo_hdr.tsn,
+                profile_id=0,
+                cluster_id=rsp_cmd,
+                data=t.SerializableBytes(data),
+                tx_options=t.TransmitOptions.NONE,
+                lqi=None,
+                rssi=None,
+            )
+        )
+
+    @staticmethod
+    def _bind_dst_address(dst_address: zdo_t.MultiAddress):
+        """Convert a ZDO bind destination into ZBOSS addressing."""
+        if dst_address.addrmode == t.AddrMode.IEEE:
+            return (
+                t_zboss.BindAddrMode.IEEE,
+                dst_address.ieee,
+                dst_address.endpoint,
+            )
+
+        # ZBOSS does not support the NWK mode for binding
+        if dst_address.addrmode != t.AddrMode.Group:
+            raise zigpy.exceptions.DeliveryError(
+                f"Unsupported bind address mode: {dst_address.addrmode!r}"
+            )
+
+        # A group destination carries no endpoint, but ZBOSS always wants one
+        return (
+            t_zboss.BindAddrMode.Group,
+            t.EUI64(
+                [
+                    dst_address.nwk % 0x100,
+                    dst_address.nwk >> 8,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ]
+            ),
+            t.uint8_t(0),
+        )
+
+    async def _bind_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO bind request and handle the response."""
+        src_ieee, src_ep, cluster_id, dst_address = zdo_args
+        addr_mode, dst_addr, dst_ep = self._bind_dst_address(dst_address)
+
+        res = await self._api.request(
+            c.ZDO.BindReq.Req(
+                TSN=self._next_tsn(),
+                TargetNwkAddr=self._target_nwk(packet),
+                SrcIEEE=src_ieee,
+                SrcEndpoint=src_ep,
+                ClusterId=cluster_id,
+                DstAddrMode=addr_mode,
+                DstAddr=dst_addr,
+                DstEndpoint=dst_ep,
+            ),
+            timeout=ZDO_TIMEOUT,
+        )
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode)
+
+    async def _unbind_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO unbind request and handle the response."""
+        src_ieee, src_ep, cluster_id, dst_address = zdo_args
+        addr_mode, dst_addr, dst_ep = self._bind_dst_address(dst_address)
+
+        res = await self._api.request(
+            c.ZDO.UnbindReq.Req(
+                TSN=self._next_tsn(),
+                TargetNwkAddr=self._target_nwk(packet),
+                SrcIEEE=src_ieee,
+                SrcEndpoint=src_ep,
+                ClusterId=cluster_id,
+                DstAddrMode=addr_mode,
+                DstAddr=dst_addr,
+                DstEndpoint=dst_ep,
+            ),
+            timeout=ZDO_TIMEOUT,
+        )
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode)
+
+    async def _node_desc_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO node descriptor request and handle the response."""
+        (nwk,) = zdo_args
+        res = await self._api.request(
+            c.ZDO.NodeDescReq.Req(TSN=self._next_tsn(), NwkAddr=nwk),
+            timeout=ZDO_TIMEOUT,
+        )
+        node_desc = None if res.StatusCode else res.NodeDesc
+
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode, nwk, node_desc)
+
+    async def _active_ep_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO active endpoints request and handle the response."""
+        (nwk,) = zdo_args
+        res = await self._api.request(
+            c.ZDO.ActiveEpReq.Req(TSN=self._next_tsn(), NwkAddr=nwk),
+            timeout=ZDO_TIMEOUT,
+        )
+        # Active_EP_rsp has no optional endpoint list, so it cannot be omitted
+        endpoints = [] if res.StatusCode else res.ActiveEpList
+
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode, nwk, endpoints)
+
+    async def _simple_desc_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO simple descriptor request and handle the response."""
+        nwk, endpoint = zdo_args
+        res = await self._api.request(
+            c.ZDO.SimpleDescriptorReq.Req(
+                TSN=self._next_tsn(), NwkAddr=nwk, Endpoint=endpoint
+            ),
+            timeout=ZDO_TIMEOUT,
+        )
+
+        if res.StatusCode:
+            desc = None
+        else:
+            desc = zdo_t.SizePrefixedSimpleDescriptor(
+                endpoint=res.SimpleDesc.endpoint,
+                profile=res.SimpleDesc.profile,
+                device_type=res.SimpleDesc.device_type,
+                device_version=res.SimpleDesc.device_version,
+                input_clusters=res.SimpleDesc.input_clusters,
+                output_clusters=res.SimpleDesc.output_clusters,
+            )
+
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode, nwk, desc)
+
+    async def _mgmt_lqi_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO LQI request and handle the response."""
+        (start_index,) = zdo_args
+        res = await self._api.request(
+            c.ZDO.MgmtLqi.Req(
+                TSN=self._next_tsn(),
+                DestNWK=self._target_nwk(packet),
+                Index=start_index,
+            ),
+            timeout=ZDO_TIMEOUT,
+        )
+        neighbors = None if res.StatusCode else res.Neighbors
+
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode, neighbors)
+
+    async def _mgmt_leave_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO leave request and handle the response."""
+        ieee, options = zdo_args
+        res = await self._api.request(
+            c.ZDO.MgtLeave.Req(
+                TSN=self._next_tsn(),
+                DestNWK=self._target_nwk(packet),
+                IEEE=t.EUI64(ieee),
+                Flags=t.uint8_t(options),
+            ),
+            timeout=ZDO_TIMEOUT,
+        )
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode)
+
+    async def _mgmt_permit_joining_req(
+            self,
+            packet: t.ZigbeePacket,
+            zdo_hdr: zdo_t.ZDOHeader,
+            zdo_args: tuple[Any]) -> None:
+        """Send ZDO permit joining request and handle the response.
+
+        `app.permit()` already broadcasts this and then opens the coordinator
+        via `permit_ncp`, so forwarding the broadcast here would send it
+        twice. Only the targeted form is translated.
+        """
+        if packet.dst.addr_mode not in (t.AddrMode.NWK, t.AddrMode.IEEE):
+            LOGGER.debug("Dropping broadcast permit joining request")
+            return
+
+        duration, tc_significance = zdo_args
+        res = await self._api.request(
+            c.ZDO.PermitJoin.Req(
+                TSN=self._next_tsn(),
+                # Targeting `self._target_nwk(packet)` would be correct, but
+                # this has always gone out as a broadcast and changing where
+                # joins are opened deserves its own change.
+                DestNWK=t.NWK(t.BroadcastAddress.RX_ON_WHEN_IDLE),
+                PermitDuration=t.uint8_t(duration),
+                TCSignificance=t.uint8_t(tc_significance),
+            ),
+            timeout=ZDO_TIMEOUT,
+        )
+        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode)
 
     async def _IEEE_addr_req(
             self,
@@ -251,17 +383,16 @@ class ZbossZDO(ZigpyZDO):
             zdo_hdr: zdo_t.ZDOHeader,
             zdo_args: tuple[Any]) -> None:
         """Send ZDO IEEE addr request and handle the response."""
-        tsn = zdo_hdr.tsn
         nwki, req_type, index = zdo_args
-        res = await self._device._application._api.request(
+        res = await self._api.request(
             c.ZDO.IeeeAddrReq.Req(
-                TSN=tsn,
+                TSN=zdo_hdr.tsn,
                 DstNWK=packet.dst.address,
                 NWKtoMatch=nwki,
                 RequestType=req_type,
                 StartIndex=index,
                 ),
-            timeout=70,
+            timeout=ZDO_TIMEOUT,
         )
 
         if res.StatusCode:
@@ -274,32 +405,31 @@ class ZbossZDO(ZigpyZDO):
             nwki = res.RemoteDevNWK
             src_ad = res.RemoteDevNWK
 
-        status = zdo_t.Status(res.StatusCode)
-        data = tsn.serialize() \
-            + status.serialize() \
-            + ieee.serialize() \
-            + nwki.serialize()
-
-        packet = t.ZigbeePacket(
+        # This request is broadcast, so the reply comes from the device that
+        # matched it rather than from the packet's destination.
+        self._send_zdo_rsp(
+            packet,
+            zdo_hdr,
+            res.StatusCode,
+            ieee,
+            nwki,
             src=t.AddrModeAddress(
                 addr_mode=t.AddrMode.NWK,
                 address=src_ad,
             ),
-            src_ep=0,
-            dst=t.AddrModeAddress(
-                addr_mode=t.AddrMode.NWK,
-                address=t.NWK(0x0000),
-            ),
-            dst_ep=0,
-            tsn=tsn,
-            profile_id=0,
-            cluster_id=zdo_t.ZDOCmd.IEEE_addr_rsp,
-            data=t.SerializableBytes(data),
-            tx_options=t.TransmitOptions.NONE,
-            lqi=None,
-            rssi=None
         )
-        self._device._application.packet_received(packet)
+
+    _ZDO_PACKET_HANDLERS = {
+        zdo_t.ZDOCmd.IEEE_addr_req: _IEEE_addr_req,
+        zdo_t.ZDOCmd.Node_Desc_req: _node_desc_req,
+        zdo_t.ZDOCmd.Simple_Desc_req: _simple_desc_req,
+        zdo_t.ZDOCmd.Active_EP_req: _active_ep_req,
+        zdo_t.ZDOCmd.Bind_req: _bind_req,
+        zdo_t.ZDOCmd.Unbind_req: _unbind_req,
+        zdo_t.ZDOCmd.Mgmt_Lqi_req: _mgmt_lqi_req,
+        zdo_t.ZDOCmd.Mgmt_Leave_req: _mgmt_leave_req,
+        zdo_t.ZDOCmd.Mgmt_Permit_Joining_req: _mgmt_permit_joining_req,
+    }
 
 
 class ZbossDevice(zigpy.device.Device):


### PR DESCRIPTION
When quirk is applied, it overwrites the ZDO device object and ZBOSS specific ZDO commands are not sent.
This way, a ZDO command is handled when a packet is sent.