### PR TITLE
Fix permit join broadcast

### DIFF
--- a/tests/application/test_join.py
+++ b/tests/application/test_join.py
@@ -17,6 +17,24 @@ async def test_permit_join(mocker, make_application):
     """Test permit join."""
     app, zboss_server = make_application(server_cls=BaseZbossDevice)
 
+    permit_join_routers = zboss_server.reply_once_to(
+        request=c.ZDO.PermitJoin.Req(
+            TSN=123,
+            DestNWK=t.NWK(
+                zigpy.types.t.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR
+            ),
+            PermitDuration=t.uint8_t(10),
+            TCSignificance=t.uint8_t(0),
+        ),
+        responses=[
+            c.ZDO.PermitJoin.Rsp(
+                TSN=123,
+                StatusCat=t.StatusCategory(1),
+                StatusCode=t.StatusCodeGeneric.OK,
+            ),
+        ],
+    )
+
     permit_join_coordinator = zboss_server.reply_once_to(
         request=c.ZDO.PermitJoin.Req(
             TSN=123,
@@ -38,6 +56,7 @@ async def test_permit_join(mocker, make_application):
 
     await asyncio.sleep(0.1)
 
+    assert permit_join_routers.done()
     assert permit_join_coordinator.done()
 
     await app.shutdown()

--- a/tests/application/test_startup.py
+++ b/tests/application/test_startup.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock as CoroutineMock
 
 import pytest
+import zigpy.types
 from zigpy.exceptions import NetworkNotFormed
 
 import zigpy_zboss.commands as c
@@ -185,9 +186,11 @@ async def test_info(make_application, caplog):
     zboss_server.reply_once_to(
         request=c.ZDO.PermitJoin.Req(
             TSN=20,
-            DestNWK=t.NWK(0x0000),
+            DestNWK=t.NWK(
+                zigpy.types.BroadcastAddress.ALL_ROUTERS_AND_COORDINATOR
+            ),
             PermitDuration=t.uint8_t(0),
-            TCSignificance=t.uint8_t(0x01),
+            TCSignificance=t.uint8_t(0),
         ),
         responses=[c.ZDO.PermitJoin.Rsp(
             TSN=20,
@@ -197,11 +200,25 @@ async def test_info(make_application, caplog):
     )
 
     zboss_server.reply_once_to(
+        request=c.ZDO.PermitJoin.Req(
+            TSN=21,
+            DestNWK=t.NWK(0x0000),
+            PermitDuration=t.uint8_t(0),
+            TCSignificance=t.uint8_t(0x01),
+        ),
+        responses=[c.ZDO.PermitJoin.Rsp(
+            TSN=21,
+            StatusCat=t.StatusCategory(4),
+            StatusCode=t.StatusCodeGeneric.OK,
+        )]
+    )
+
+    zboss_server.reply_once_to(
         request=c.NcpConfig.NCPModuleReset.Req(
-            TSN=21, Option=t.ResetOptions(0)
+            TSN=22, Option=t.ResetOptions(0)
         ),
         responses=[c.NcpConfig.NCPModuleReset.Rsp(
-            TSN=21,
+            TSN=22,
             StatusCat=t.StatusCategory(4),
             StatusCode=t.StatusCodeGeneric.OK
         )]
@@ -231,15 +248,15 @@ async def test_endpoints(make_application):
     """Test endpoints."""
     app, zboss_server = make_application(server_cls=BaseZbossDevice)
 
-    endpoints = []
+    permit_requests = []
     zboss_server.register_indication_listener(
-        c.ZDO.PermitJoin.Req(partial=True), endpoints.append
+        c.ZDO.PermitJoin.Req(partial=True), permit_requests.append
     )
 
     await app.startup(auto_form=False)
 
-    # We currently just register one endpoint
-    assert len(endpoints) == 1
+    # Startup closes joins network-wide and then on the coordinator
+    assert len(permit_requests) == 2
     assert 1 in app._device.endpoints
 
     await app.shutdown()

--- a/zigpy_zboss/zigbee/device.py
+++ b/zigpy_zboss/zigbee/device.py
@@ -3,10 +3,8 @@ import logging
 from typing import Any
 
 import zigpy.device
-import zigpy.endpoint
 import zigpy.exceptions
 import zigpy.types as t
-import zigpy.util
 from zigpy.zdo import ZDO as ZigpyZDO
 from zigpy.zdo import types as zdo_t
 
@@ -32,24 +30,6 @@ class ZbossZDO(ZigpyZDO):
     hook lives on the coordinator, which is never quirked, so every device
     takes the same path and gets standard zigpy return values.
     """
-
-    def handle_mgmt_permit_joining_req(
-        self,
-        permit_duration: int,
-        tc_significance: int,
-    ):
-        """Handle ZDO permit joining request."""
-        hdr = zdo_t.ZDOHeader(zdo_t.ZDOCmd.Mgmt_Permit_Joining_req, 0)
-        dst_addressing = t.Addressing.IEEE
-
-        self.listener_event("permit_duration", permit_duration)
-        self.listener_event(
-            "zdo_mgmt_permit_joining_req",
-            self._device,
-            dst_addressing,
-            hdr,
-            (permit_duration, tc_significance),
-        )
 
     async def Mgmt_NWK_Update_req(self, nwkUpdate):
         """Issue a ZDO Mgmt_NWK_Update (energy scan / channel change).
@@ -352,30 +332,27 @@ class ZbossZDO(ZigpyZDO):
             packet: t.ZigbeePacket,
             zdo_hdr: zdo_t.ZDOHeader,
             zdo_args: tuple[Any]) -> None:
-        """Send ZDO permit joining request and handle the response.
+        """Send ZDO permit joining request and handle the response."""
+        is_unicast = packet.dst.addr_mode in (t.AddrMode.NWK, t.AddrMode.IEEE)
 
-        `app.permit()` already broadcasts this and then opens the coordinator
-        via `permit_ncp`, so forwarding the broadcast here would send it
-        twice. Only the targeted form is translated.
-        """
-        if packet.dst.addr_mode not in (t.AddrMode.NWK, t.AddrMode.IEEE):
-            LOGGER.debug("Dropping broadcast permit joining request")
-            return
+        if is_unicast:
+            dest_nwk = t.NWK(t.BroadcastAddress.RX_ON_WHEN_IDLE)
+        else:
+            dest_nwk = t.NWK(packet.dst.address)
 
         duration, tc_significance = zdo_args
         res = await self._api.request(
             c.ZDO.PermitJoin.Req(
                 TSN=self._next_tsn(),
-                # Targeting `self._target_nwk(packet)` would be correct, but
-                # this has always gone out as a broadcast and changing where
-                # joins are opened deserves its own change.
-                DestNWK=t.NWK(t.BroadcastAddress.RX_ON_WHEN_IDLE),
+                DestNWK=dest_nwk,
                 PermitDuration=t.uint8_t(duration),
                 TCSignificance=t.uint8_t(tc_significance),
             ),
             timeout=ZDO_TIMEOUT,
         )
-        self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode)
+
+        if is_unicast:
+            self._send_zdo_rsp(packet, zdo_hdr, res.StatusCode)
 
     async def _IEEE_addr_req(
             self,


### PR DESCRIPTION
Closes #87 

Before, ZDO permit join requests was only addressed to the coordinator (0x0000) which caused the routers in the network not permiting joins through them (mesh broken).
